### PR TITLE
feat(Replay): add .apples to show collected apples

### DIFF
--- a/__tests__/rec.int.test.ts
+++ b/__tests__/rec.int.test.ts
@@ -210,4 +210,15 @@ describe('Replay', () => {
       expect(replay.toBuffer()).toEqual(file);
     },
   );
+
+  test.each([
+    ['rec_valid_1.rec', 2],
+    ['rec_valid_2.rec', 4],
+    ['rec_valid_3.rec', 4],
+  ])('.apples counts correct number of apples: %s', async (fileName, apples) => {
+    const filePath = `__tests__/assets/replays/${fileName}`;
+    const file = await readFile(filePath);
+    const replay = Replay.from(file);
+    expect(replay.apples).toEqual(apples);
+  });
 });

--- a/src/rec/Replay.ts
+++ b/src/rec/Replay.ts
@@ -275,4 +275,17 @@ export default class Replay {
       time: Math.round(maxEventTime),
     };
   }
+
+  /**
+   * Returns the number of apples collected in the replay.
+   *
+   * @returns Number of apples
+   */
+  get apples(): number {
+    const apples = this.rides.reduce((apples, ride) => {
+      apples += ride.events.filter((event) => event.type === 4).length;
+      return apples;
+    }, 0);
+    return apples;
+  }
 }


### PR DESCRIPTION
Adds a getter for `apples` field in `Replay` that returns the number of apples collected in the replay.

Fixes #184 