### PR TITLE
build: add missing build step id

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ jobs:
         uses: codecov/codecov-action@v1
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@v2
+        id: semantic
         with:
           extra_plugins: |
             @semantic-release/changelog@3.0.0


### PR DESCRIPTION
The next steps would never run even if a new build was published, because the `steps.semantic.*` value would never exist, as there was no id attached to the previous semantic release step